### PR TITLE
feat: improve mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,21 +6,41 @@ body {
 
 #buttons {
   margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .sound-button {
-  margin: 5px;
-  padding: 10px 20px;
+  display: block;
+  width: 80%;
+  max-width: 300px;
+  margin: 8px 0;
+  padding: 14px;
   font-size: 1rem;
+  min-height: 44px;
 }
 
 #player-controls {
   margin-top: 20px;
 }
 
+#audioPlayer {
+  display: block;
+  width: 80%;
+  max-width: 300px;
+  margin: 0 auto 10px;
+}
+
+.control-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
 .control-buttons button {
-  margin: 0 5px;
-  padding: 5px 10px;
+  padding: 10px 16px;
+  min-height: 44px;
 }
 
 .home-button {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Singaseong SFX</title>
   <link rel="icon" href="src/favicon.ico" />
   <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- add viewport meta tag for responsive scaling
- stack sound buttons vertically with larger touch targets
- scale audio player and controls for mobile screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b942a75eac832ab38a3055fcf33517