### PR TITLE
Add repeat toggle for audio player

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,12 @@
     <button class="sound-button" data-sound="src/sounds/soccer_whistle.mp3">Soccer Whistle</button>
   </div>
   <div id="player-controls">
-    <audio id="audioPlayer" controls></audio>
+    <audio id="audioPlayer" controls loop></audio>
     <div class="control-buttons">
       <button id="playBtn">Play</button>
       <button id="pauseBtn">Pause</button>
       <button id="stopBtn">Stop</button>
+      <button id="loopToggleBtn">Repeat: On</button>
     </div>
   </div>
   <script src="js/script.js"></script>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
 const audioPlayer = document.getElementById('audioPlayer');
+audioPlayer.loop = true;
 
 document.querySelectorAll('.sound-button').forEach(button => {
   button.addEventListener('click', () => {
@@ -21,4 +22,11 @@ document.getElementById('pauseBtn').addEventListener('click', () => {
 document.getElementById('stopBtn').addEventListener('click', () => {
   audioPlayer.pause();
   audioPlayer.currentTime = 0;
+});
+
+const loopToggleBtn = document.getElementById('loopToggleBtn');
+loopToggleBtn.textContent = 'Repeat: On';
+loopToggleBtn.addEventListener('click', () => {
+  audioPlayer.loop = !audioPlayer.loop;
+  loopToggleBtn.textContent = audioPlayer.loop ? 'Repeat: On' : 'Repeat: Off';
 });


### PR DESCRIPTION
## Summary
- Enable audio player looping by default
- Add Repeat On/Off toggle button to player controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c10c2aad60832a83ca7803b8524cdc