### PR TITLE
feat: color repeat button states

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,3 +53,11 @@ body {
   opacity: 0.6;
   z-index: 1000;
 }
+
+#loopToggleBtn.on {
+  background-color: lightyellow;
+}
+
+#loopToggleBtn.off {
+  background-color: gray;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -26,7 +26,16 @@ document.getElementById('stopBtn').addEventListener('click', () => {
 
 const loopToggleBtn = document.getElementById('loopToggleBtn');
 loopToggleBtn.textContent = 'Repeat: On';
+loopToggleBtn.classList.add('on');
 loopToggleBtn.addEventListener('click', () => {
   audioPlayer.loop = !audioPlayer.loop;
-  loopToggleBtn.textContent = audioPlayer.loop ? 'Repeat: On' : 'Repeat: Off';
+  if (audioPlayer.loop) {
+    loopToggleBtn.textContent = 'Repeat: On';
+    loopToggleBtn.classList.add('on');
+    loopToggleBtn.classList.remove('off');
+  } else {
+    loopToggleBtn.textContent = 'Repeat: Off';
+    loopToggleBtn.classList.add('off');
+    loopToggleBtn.classList.remove('on');
+  }
 });


### PR DESCRIPTION
## Summary
- style repeat button with light yellow when looping and gray when not
- toggle loop button classes on click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c110f3089c832a81082b58b5ce3754