### PR TITLE
Lighten control button colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,17 +44,18 @@ body {
 }
 
 #playBtn {
-  background-color: green;
-  color: white;
+  background-color: lightgreen;
+  color: black;
 }
 
 #pauseBtn {
-  background-color: yellow;
+  background-color: lemonchiffon;
+  color: black;
 }
 
 #stopBtn {
-  background-color: red;
-  color: white;
+  background-color: lightcoral;
+  color: black;
 }
 
 .home-button {
@@ -73,5 +74,5 @@ body {
 }
 
 #loopToggleBtn.off {
-  background-color: gray;
+  background-color: lightgray;
 }


### PR DESCRIPTION
## Summary
- Brighten play, pause, and stop buttons with pastel backgrounds and readable text.
- Soften inactive repeat button using a lighter gray tone.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c1148673bc832a87579c9b3fe783ad